### PR TITLE
Added 2 missing statements for compile time

### DIFF
--- a/example/lib/CollectionView.js
+++ b/example/lib/CollectionView.js
@@ -1,3 +1,8 @@
+// The two following statements are required so Titanium can detect the 
+// use of ListView and RefreshControl at compile time. 
+Ti.UI.createListView();
+Ti.UI.createRefreshControl();
+
 function createCollectionView(options) {
 	if( OS_IOS )
 	{

--- a/lib/CollectionView.js
+++ b/lib/CollectionView.js
@@ -1,3 +1,8 @@
+// The two following statements are required so Titanium can detect the 
+// use of ListView and RefreshControl at compile time. 
+Ti.UI.createListView();
+Ti.UI.createRefreshControl();
+
 function createCollectionView(options) {
 	if( OS_IOS )
 	{


### PR DESCRIPTION
Those two statements are required so Titanium can detect the use of
ListView and RefreshControl at compile time.